### PR TITLE
test: comprehensive test suite — 78 new tests across all modules

### DIFF
--- a/examples/config-comprehensive.toml
+++ b/examples/config-comprehensive.toml
@@ -1,0 +1,355 @@
+# =============================================================================
+# Automatic Secret Rotation — Comprehensive Configuration Reference
+# =============================================================================
+# This file documents every available option across all backends and targets.
+# It is intentionally verbose; a real deployment only needs the sections
+# relevant to your environment.
+#
+# Quick-start:
+#   asr init            # generates a minimal config interactively
+#   asr validate        # checks this file for errors
+#   asr scan            # shows secrets overdue for rotation
+#   asr rotate <path>   # rotates a single secret in the backend
+# =============================================================================
+
+# Which secret store to use as the source of truth.
+# Options: vault | aws | azure | gcp | ocp | file
+backend = "vault"
+
+# =============================================================================
+# Backend: HashiCorp Vault (KV v2)
+# =============================================================================
+[vault]
+address = "https://vault.example.com:8200"
+
+# KV v2 mount (default: "secret").  Change if your org uses a different mount
+# such as "kv", "infra", "app-secrets", etc.
+mount = "secret"
+
+# --- Auth method (choose ONE; all others can be left commented out) ----------
+
+# Option 1 — Static token (dev / break-glass only; not recommended for prod)
+auth_method = "token"
+# token = "hvs.CAESI..."              # or set VAULT_TOKEN env var
+
+# Option 2 — AppRole (CI pipelines, automated agents)
+# auth_method = "approle"
+# [vault.approle]
+# role_id      = "6cf1dbf4-7c14-4b3a-bc2e-1a3b5e6f7a8b"  # non-secret; commit it
+# secret_id_env = "VAULT_SECRET_ID"  # injected by your CI/CD at runtime
+# mount        = "approle"           # default; omit if unchanged
+
+# Option 3 — Kubernetes / OpenShift (pods with a mounted ServiceAccount token)
+# auth_method = "kubernetes"
+# [vault.kubernetes]
+# role          = "asr-rotation-role"
+# sa_token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"  # default
+# mount         = "kubernetes"
+
+# Option 4 — AWS IAM (EC2 instance profile, EKS IRSA, Lambda — zero secrets)
+# auth_method = "aws_iam"
+# [vault.aws_iam]
+# role         = "asr-vault-role"
+# header_value = "vault.example.com"  # X-Vault-AWS-IAM-Server-ID (optional)
+# mount        = "aws"
+
+# Option 5 — JWT / OIDC (GitHub Actions, GitLab CI — token auto-detected)
+# auth_method = "jwt"
+# [vault.jwt]
+# role      = "github-actions-asr"
+# token_env = "ACTIONS_ID_TOKEN"     # explicit env var; auto-detected if unset
+# mount     = "jwt"
+
+# =============================================================================
+# Backend: AWS Secrets Manager (alternative to Vault)
+# =============================================================================
+# Activate with: backend = "aws"
+# AWS credentials come from the standard chain (env vars, ~/.aws, IAM role).
+#
+# [aws]
+# region = "us-east-1"
+
+# =============================================================================
+# Backend: Azure Key Vault (alternative to Vault)
+# =============================================================================
+# Activate with: backend = "azure"
+# Authenticates via DefaultAzureCredential (env vars → managed identity → CLI).
+#
+# [azure]
+# vault_url = "https://my-keyvault.vault.azure.net"
+# tenant_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  # optional override
+
+# =============================================================================
+# Backend: GCP Secret Manager (alternative to Vault)
+# =============================================================================
+# Activate with: backend = "gcp"
+# Authenticates via Application Default Credentials.
+#
+# [gcp]
+# project_id       = "my-gcp-project-id"
+# credentials_file = "/etc/gcp/sa-key.json"  # omit to use ADC / Workload Identity
+
+# =============================================================================
+# Backend: OpenShift / Kubernetes Secrets (alternative to Vault)
+# =============================================================================
+# Activate with: backend = "ocp"
+# Requires --features ocp at build time.
+#
+# [ocp]
+# namespace  = "my-app-namespace"
+# kubeconfig = "/home/ci/.kube/config"   # omit for in-cluster auth
+# context    = "prod-cluster"            # omit to use active context
+
+# =============================================================================
+# Backend: Local file system (dev / offline / testing only)
+# =============================================================================
+# Activate with: backend = "file"
+#
+# [file]
+# directory = "~/.asr/secrets"   # default
+
+# =============================================================================
+# Global rotation settings
+# =============================================================================
+[rotation]
+# How many months between rotations (default: 6).
+# A secret is overdue once `last_rotated` is older than this.
+period_months = 3
+
+# Length of auto-generated secrets in characters (default: 32).
+# Use 64+ for high-value secrets; APIs may impose their own limits.
+secret_length = 48
+
+# =============================================================================
+# Targets — where rotated secrets get applied
+#
+# Use the [[targets]] array form to define multiple targets.
+# Each entry requires a `type` field; the available types are:
+#   postgres | mysql | api | gitlab | github
+#
+# Secrets in the backend are rotated first, then propagated to each target.
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# PostgreSQL — primary application database
+# ---------------------------------------------------------------------------
+[[targets]]
+type     = "postgres"
+host     = "postgres-primary.db.internal"
+port     = 5432
+database = "app_production"
+username = "app_user"
+# password_path: path in the secret backend where the current admin password
+# lives.  The rotator reads this to authenticate before changing the password.
+password_path = "infra/postgres/primary/admin-password"
+ssl_mode = "verify-full"
+
+# ---------------------------------------------------------------------------
+# PostgreSQL — read replica (same user, same password — rotated in sync)
+# ---------------------------------------------------------------------------
+[[targets]]
+type          = "postgres"
+host          = "postgres-replica.db.internal"
+port          = 5432
+database      = "app_production"
+username      = "app_user"
+password_path = "infra/postgres/primary/admin-password"
+ssl_mode      = "verify-full"
+
+# ---------------------------------------------------------------------------
+# PostgreSQL — analytics / reporting database (different credentials)
+# ---------------------------------------------------------------------------
+[[targets]]
+type          = "postgres"
+host          = "analytics.db.internal"
+port          = 5432
+database      = "analytics"
+username      = "etl_writer"
+password_path = "infra/postgres/analytics/etl-writer-password"
+ssl_mode      = "require"
+
+# ---------------------------------------------------------------------------
+# MySQL — legacy service database
+# ---------------------------------------------------------------------------
+[[targets]]
+type          = "mysql"
+host          = "mysql.db.internal"
+port          = 3306
+database      = "legacy_app"
+username      = "svc_account"
+password_path = "infra/mysql/legacy/svc-account-password"
+ssl_mode      = "required"
+
+# ---------------------------------------------------------------------------
+# API — internal user management service
+# Sends a POST /api/v1/users/{username}/password with the new password.
+# ---------------------------------------------------------------------------
+[[targets]]
+type             = "api"
+base_url         = "https://usermgmt.internal"
+endpoint         = "/api/v1/users/{username}/password"
+method           = "PUT"
+password_field   = "new_password"
+username_field   = "username"
+auth_header      = "Bearer ${API_ADMIN_TOKEN}"
+timeout_seconds  = 30
+
+[targets.additional_fields]
+confirm_password = "{password}"   # some APIs require confirmation
+
+# ---------------------------------------------------------------------------
+# API — Stripe restricted key rotation webhook
+# Stripe doesn't support password-style rotation; this calls an internal
+# proxy that rolls the key via the Stripe API and returns the new value.
+# ---------------------------------------------------------------------------
+[[targets]]
+type            = "api"
+base_url        = "https://secrets-proxy.internal"
+endpoint        = "/rotate/stripe"
+method          = "POST"
+password_field  = "new_key"
+auth_header     = "Bearer ${SECRETS_PROXY_TOKEN}"
+timeout_seconds = 60
+
+# ---------------------------------------------------------------------------
+# API — DataDog synthetic monitoring password update
+# ---------------------------------------------------------------------------
+[[targets]]
+type            = "api"
+base_url        = "https://api.datadoghq.com"
+endpoint        = "/api/v1/synthetics/settings/variables/{username}"
+method          = "PUT"
+password_field  = "value"
+auth_header     = "DD-API-KEY ${DD_API_KEY}"
+timeout_seconds = 30
+
+# ---------------------------------------------------------------------------
+# GitLab CI/CD — deploy token stored as a CI variable (requires: --features gitlab)
+# ---------------------------------------------------------------------------
+[[targets]]
+type         = "gitlab"
+project_id   = "myorg/backend-service"   # path or numeric ID; slashes are encoded
+variable_key = "DEPLOY_TOKEN"
+# gitlab_url = "https://gitlab.example.com"   # default: https://gitlab.com
+token_path   = "cicd/gitlab/rotator-token"    # token read from secret backend
+masked       = true
+protected    = false
+
+# ---------------------------------------------------------------------------
+# GitLab CI/CD — database password propagated to a mono-repo
+# ---------------------------------------------------------------------------
+[[targets]]
+type         = "gitlab"
+project_id   = "myorg/platform"
+variable_key = "PROD_DB_PASSWORD"
+token_path   = "cicd/gitlab/rotator-token"
+masked       = true
+protected    = true
+
+# ---------------------------------------------------------------------------
+# GitLab CI/CD — self-hosted instance
+# ---------------------------------------------------------------------------
+[[targets]]
+type         = "gitlab"
+project_id   = "42"                          # numeric project ID
+variable_key = "REGISTRY_PASSWORD"
+gitlab_url   = "https://gitlab.corp.example.com"
+token_path   = "cicd/gitlab-internal/rotator-token"
+masked       = true
+
+# ---------------------------------------------------------------------------
+# GitHub Actions — repo-level encrypted secret (requires: --features github)
+# secret_name uses libsodium sealed-box encryption (matches GitHub API spec)
+# ---------------------------------------------------------------------------
+[[targets]]
+type        = "github"
+owner       = "myorg"
+repo        = "backend-service"
+secret_name = "PROD_DB_PASSWORD"
+token_path  = "cicd/github/rotator-pat"     # fine-grained PAT from secret backend
+
+# ---------------------------------------------------------------------------
+# GitHub Actions — environment-scoped secret (Production environment gate)
+# ---------------------------------------------------------------------------
+[[targets]]
+type        = "github"
+owner       = "myorg"
+repo        = "backend-service"
+secret_name = "STRIPE_SECRET_KEY"
+env_name    = "production"                  # scoped to the "production" environment
+token_path  = "cicd/github/rotator-pat"
+
+# ---------------------------------------------------------------------------
+# GitHub Actions — plaintext variable (non-sensitive config values)
+# variable_name uses the unencrypted Actions Variables API (PATCH / POST)
+# ---------------------------------------------------------------------------
+[[targets]]
+type          = "github"
+owner         = "myorg"
+repo          = "frontend"
+variable_name = "NEXT_PUBLIC_API_URL"
+token_path    = "cicd/github/rotator-pat"
+
+# ---------------------------------------------------------------------------
+# GitHub Actions — secret in a second organization repo
+# ---------------------------------------------------------------------------
+[[targets]]
+type        = "github"
+owner       = "myorg"
+repo        = "data-pipeline"
+secret_name = "SNOWFLAKE_PASSWORD"
+env_name    = "production"
+token_path  = "cicd/github/rotator-pat"
+
+# =============================================================================
+# Audit log — append-only JSONL record of every rotation event
+# Each line is a self-contained JSON object (schema_version, event, path, etc.)
+# Compatible with Splunk, Datadog Logs, CloudWatch, and jq.
+# =============================================================================
+[audit]
+log_file = "/var/log/asr/audit.jsonl"
+stdout   = false   # set true to also emit events to stdout (useful in containers)
+
+# =============================================================================
+# Notifications — POST a JSON payload to a webhook on rotation events
+# Compatible with Slack incoming webhooks, PagerDuty Events API v2,
+# Opsgenie, Discord, and any HTTP endpoint.
+# =============================================================================
+[notification]
+webhook_url  = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXX"
+auth_header  = "Bearer ${ASR_WEBHOOK_TOKEN}"   # optional; omit for Slack
+# events controls which operations send a notification (default: all three)
+events = ["rotate", "flag", "scan"]
+
+# =============================================================================
+# Secret paths tracked in the backend
+# =============================================================================
+# The config file above defines HOW the rotator connects and WHERE it propagates
+# secrets.  The list of WHICH secrets to rotate lives in the backend itself
+# (metadata attached to each secret path).
+#
+# To flag a secret for automatic rotation:
+#   asr flag infra/postgres/primary/admin-password     --period 3
+#   asr flag infra/mysql/legacy/svc-account-password   --period 6
+#   asr flag app/stripe/secret-key                     --period 1
+#   asr flag app/sendgrid/api-key                      --period 3
+#   asr flag app/jwt/signing-key                       --period 6
+#   asr flag app/session-secret                        --period 6
+#   asr flag app/hmac-key                              --period 12
+#   asr flag app/redis/auth-token                      --period 3
+#   asr flag app/rabbitmq/password                     --period 6
+#   asr flag app/elasticsearch/password                --period 6
+#   asr flag app/datadog/api-key                       --period 3
+#   asr flag app/pagerduty/integration-key             --period 12
+#   asr flag app/twilio/auth-token                     --period 3
+#   asr flag cicd/github/rotator-pat                   --period 3
+#   asr flag cicd/gitlab/rotator-token                 --period 3
+#   asr flag cicd/gitlab-internal/rotator-token        --period 3
+#
+# To see which secrets are overdue:
+#   asr scan
+#   asr scan --path infra/postgres
+#
+# To rotate a specific secret (and propagate to all matching targets):
+#   asr rotate infra/postgres/primary/admin-password
+#   asr rotate app/stripe/secret-key

--- a/src/backends/file.rs
+++ b/src/backends/file.rs
@@ -233,8 +233,10 @@ impl SecretBackend for FileBackend {
                 }
 
                 if file_path.is_file() {
-                    // Get relative path from base_dir, normalizing to forward slashes
-                    if let Ok(relative) = file_path.strip_prefix(&self.base_dir) {
+                    // Strip dir_path (not base_dir) so callers receive names relative to the
+                    // queried prefix — matches Vault's LIST behaviour and prevents scan_for_rotation
+                    // from double-prefixing paths when called with a non-empty root.
+                    if let Ok(relative) = file_path.strip_prefix(&dir_path) {
                         let secret_path = relative
                             .to_string_lossy()
                             .replace(std::path::MAIN_SEPARATOR, "/");
@@ -242,18 +244,17 @@ impl SecretBackend for FileBackend {
                     }
                 } else if file_path.is_dir() {
                     // Recursively list secrets in subdirectories
+                    let sub_name = file_path.file_name().unwrap().to_string_lossy().to_string();
                     let sub_path = if path.is_empty() {
-                        file_path.file_name().unwrap().to_string_lossy().to_string()
+                        sub_name.clone()
                     } else {
-                        format!(
-                            "{}/{}",
-                            path,
-                            file_path.file_name().unwrap().to_string_lossy()
-                        )
+                        format!("{}/{}", path, sub_name)
                     };
 
                     let sub_secrets = self.list_secrets(&sub_path).await?;
-                    secrets.extend(sub_secrets);
+                    for s in sub_secrets {
+                        secrets.push(format!("{}/{}", sub_name, s));
+                    }
                 }
             }
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -328,6 +328,10 @@ pub struct GitHubTargetConfig {
     /// GitHub Environment name to scope the secret/variable (optional)
     #[serde(default)]
     pub env_name: Option<String>,
+    /// Override the GitHub API base URL (default: https://api.github.com).
+    /// Intended for testing against a mock server; not needed in production.
+    #[serde(default)]
+    pub api_url: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/targets/github.rs
+++ b/src/targets/github.rs
@@ -11,6 +11,7 @@ const GITHUB_API: &str = "https://api.github.com";
 const API_VERSION: &str = "2022-11-28";
 
 pub struct GitHubTarget {
+    api_base: String,
     owner: String,
     repo: String,
     secret_name: Option<String>,
@@ -45,6 +46,12 @@ impl GitHubTarget {
             .context("GitHub token not set — provide token in config or set GITHUB_TOKEN")?;
 
         Ok(Self {
+            api_base: config
+                .api_url
+                .as_deref()
+                .unwrap_or(GITHUB_API)
+                .trim_end_matches('/')
+                .to_string(),
             owner: config.owner.clone(),
             repo: config.repo.clone(),
             secret_name: config.secret_name.clone(),
@@ -75,11 +82,11 @@ impl GitHubTarget {
         let pk_url = match &self.env_name {
             Some(env) => format!(
                 "{}/repos/{}/{}/environments/{}/secrets/public-key",
-                GITHUB_API, self.owner, self.repo, env
+                self.api_base, self.owner, self.repo, env
             ),
             None => format!(
                 "{}/repos/{}/{}/actions/secrets/public-key",
-                GITHUB_API, self.owner, self.repo
+                self.api_base, self.owner, self.repo
             ),
         };
 
@@ -104,11 +111,11 @@ impl GitHubTarget {
         let secret_url = match &self.env_name {
             Some(env) => format!(
                 "{}/repos/{}/{}/environments/{}/secrets/{}",
-                GITHUB_API, self.owner, self.repo, env, name
+                self.api_base, self.owner, self.repo, env, name
             ),
             None => format!(
                 "{}/repos/{}/{}/actions/secrets/{}",
-                GITHUB_API, self.owner, self.repo, name
+                self.api_base, self.owner, self.repo, name
             ),
         };
 
@@ -141,21 +148,21 @@ impl GitHubTarget {
             Some(env) => (
                 format!(
                     "{}/repos/{}/{}/environments/{}/variables",
-                    GITHUB_API, self.owner, self.repo, env
+                    self.api_base, self.owner, self.repo, env
                 ),
                 format!(
                     "{}/repos/{}/{}/environments/{}/variables/{}",
-                    GITHUB_API, self.owner, self.repo, env, name
+                    self.api_base, self.owner, self.repo, env, name
                 ),
             ),
             None => (
                 format!(
                     "{}/repos/{}/{}/actions/variables",
-                    GITHUB_API, self.owner, self.repo
+                    self.api_base, self.owner, self.repo
                 ),
                 format!(
                     "{}/repos/{}/{}/actions/variables/{}",
-                    GITHUB_API, self.owner, self.repo, name
+                    self.api_base, self.owner, self.repo, name
                 ),
             ),
         };
@@ -209,7 +216,7 @@ impl Target for GitHubTarget {
         _password: &str,
         _extra: Option<&str>,
     ) -> Result<()> {
-        let url = format!("{}/repos/{}/{}", GITHUB_API, self.owner, self.repo);
+        let url = format!("{}/repos/{}/{}", self.api_base, self.owner, self.repo);
         let resp = self
             .gh_request(reqwest::Method::GET, &url)
             .send()

--- a/tests/audit_tests.rs
+++ b/tests/audit_tests.rs
@@ -43,8 +43,7 @@ fn test_audit_event_defaults() {
 
 #[test]
 fn test_audit_event_with_error_sets_failed_status() {
-    let ev = AuditEvent::new("rotate", "app/db", "vault")
-        .with_error("connection refused");
+    let ev = AuditEvent::new("rotate", "app/db", "vault").with_error("connection refused");
     assert_eq!(ev.status, "failed");
     assert_eq!(ev.error.as_deref(), Some("connection refused"));
 }
@@ -189,19 +188,15 @@ fn test_audit_logger_multiple_events_append_not_overwrite() {
 #[test]
 fn test_audit_logger_creates_parent_directories() {
     let dir = TempDir::new().unwrap();
-    let log_path = dir
-        .path()
-        .join("deeply")
-        .join("nested")
-        .join("audit.jsonl");
+    let log_path = dir.path().join("deeply").join("nested").join("audit.jsonl");
     let logger = AuditLogger::new(&file_config(log_path.to_str().unwrap()));
 
     logger.log(&AuditEvent::new("rotate", "app/db", "file"));
 
     assert!(log_path.exists(), "log file should have been created");
     let contents = std::fs::read_to_string(&log_path).unwrap();
-    let _: serde_json::Value = serde_json::from_str(contents.trim())
-        .expect("written line must be valid JSON");
+    let _: serde_json::Value =
+        serde_json::from_str(contents.trim()).expect("written line must be valid JSON");
 }
 
 #[test]
@@ -221,5 +216,8 @@ fn test_audit_logger_no_op_when_disabled() {
 #[test]
 fn test_audit_event_asr_version_is_present() {
     let ev = AuditEvent::new("rotate", "app/db", "vault");
-    assert!(!ev.asr_version.is_empty(), "asr_version should be populated");
+    assert!(
+        !ev.asr_version.is_empty(),
+        "asr_version should be populated"
+    );
 }

--- a/tests/audit_tests.rs
+++ b/tests/audit_tests.rs
@@ -1,0 +1,225 @@
+use secret_rotator::audit::{AuditEvent, AuditLogger};
+use secret_rotator::config::AuditConfig;
+use tempfile::TempDir;
+
+fn disabled_config() -> AuditConfig {
+    AuditConfig {
+        log_file: None,
+        stdout: false,
+    }
+}
+
+fn file_config(path: &str) -> AuditConfig {
+    AuditConfig {
+        log_file: Some(path.to_string()),
+        stdout: false,
+    }
+}
+
+fn stdout_config() -> AuditConfig {
+    AuditConfig {
+        log_file: None,
+        stdout: true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AuditEvent builder
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_audit_event_defaults() {
+    let ev = AuditEvent::new("rotate", "app/db", "vault");
+    assert_eq!(ev.event, "rotate");
+    assert_eq!(ev.path, "app/db");
+    assert_eq!(ev.backend, "vault");
+    assert_eq!(ev.status, "success");
+    assert_eq!(ev.duration_ms, 0);
+    assert!(ev.error.is_none());
+    assert!(ev.target.is_none());
+    assert!(ev.username.is_none());
+    assert_eq!(ev.schema_version, "1");
+}
+
+#[test]
+fn test_audit_event_with_error_sets_failed_status() {
+    let ev = AuditEvent::new("rotate", "app/db", "vault")
+        .with_error("connection refused");
+    assert_eq!(ev.status, "failed");
+    assert_eq!(ev.error.as_deref(), Some("connection refused"));
+}
+
+#[test]
+fn test_audit_event_with_duration() {
+    let ev = AuditEvent::new("rotate", "app/db", "vault").with_duration(150);
+    assert_eq!(ev.duration_ms, 150);
+}
+
+#[test]
+fn test_audit_event_with_target() {
+    let ev = AuditEvent::new("rotate", "app/db", "vault").with_target("PostgresDB");
+    assert_eq!(ev.target.as_deref(), Some("PostgresDB"));
+}
+
+#[test]
+fn test_audit_event_with_username() {
+    let ev = AuditEvent::new("rotate", "app/db", "vault").with_username("admin");
+    assert_eq!(ev.username.as_deref(), Some("admin"));
+}
+
+#[test]
+fn test_audit_event_with_status() {
+    let ev = AuditEvent::new("rotate", "app/db", "vault").with_status("skipped");
+    assert_eq!(ev.status, "skipped");
+}
+
+#[test]
+fn test_audit_event_serializes_to_valid_json() {
+    let ev = AuditEvent::new("rotate", "app/db", "vault")
+        .with_duration(42)
+        .with_target("MySQL")
+        .with_username("root");
+    let json = serde_json::to_string(&ev).expect("serialization should succeed");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json).expect("serialized output must be valid JSON");
+    assert_eq!(parsed["event"], "rotate");
+    assert_eq!(parsed["path"], "app/db");
+    assert_eq!(parsed["backend"], "vault");
+    assert_eq!(parsed["status"], "success");
+    assert_eq!(parsed["duration_ms"], 42);
+    assert_eq!(parsed["target"], "MySQL");
+    assert_eq!(parsed["username"], "root");
+}
+
+#[test]
+fn test_audit_event_error_field_skipped_when_absent() {
+    let ev = AuditEvent::new("rotate", "app/db", "vault");
+    let json = serde_json::to_string(&ev).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(
+        parsed.get("error").is_none(),
+        "error key should be omitted when None"
+    );
+    assert!(
+        parsed.get("target").is_none(),
+        "target key should be omitted when None"
+    );
+    assert!(
+        parsed.get("username").is_none(),
+        "username key should be omitted when None"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AuditLogger — enabled / disabled
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_audit_logger_disabled_when_no_file_no_stdout() {
+    let logger = AuditLogger::new(&disabled_config());
+    assert!(!logger.is_enabled());
+}
+
+#[test]
+fn test_audit_logger_enabled_when_file_configured() {
+    let logger = AuditLogger::new(&file_config("/tmp/asr-test-audit.jsonl"));
+    assert!(logger.is_enabled());
+}
+
+#[test]
+fn test_audit_logger_enabled_when_stdout() {
+    let logger = AuditLogger::new(&stdout_config());
+    assert!(logger.is_enabled());
+}
+
+// ---------------------------------------------------------------------------
+// AuditLogger — file writes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_audit_logger_writes_jsonl_to_file() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("audit.jsonl");
+    let logger = AuditLogger::new(&file_config(log_path.to_str().unwrap()));
+
+    let ev = AuditEvent::new("rotate", "app/db", "vault");
+    logger.log(&ev);
+
+    let contents = std::fs::read_to_string(&log_path).expect("log file should exist");
+    let line = contents.trim();
+    assert!(!line.is_empty(), "log file should not be empty");
+    let parsed: serde_json::Value =
+        serde_json::from_str(line).expect("log line must be valid JSON");
+    assert_eq!(parsed["event"], "rotate");
+    assert_eq!(parsed["path"], "app/db");
+}
+
+#[test]
+fn test_audit_logger_multiple_events_append_not_overwrite() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("audit.jsonl");
+    let logger = AuditLogger::new(&file_config(log_path.to_str().unwrap()));
+
+    logger.log(&AuditEvent::new("rotate", "app/secret1", "vault"));
+    logger.log(&AuditEvent::new("rotate", "app/secret2", "vault"));
+    logger.log(&AuditEvent::new("flag", "app/secret3", "vault"));
+
+    let contents = std::fs::read_to_string(&log_path).unwrap();
+    let lines: Vec<&str> = contents.lines().collect();
+    assert_eq!(lines.len(), 3, "should have 3 lines");
+
+    for line in &lines {
+        let parsed: serde_json::Value =
+            serde_json::from_str(line).expect("each line must be valid JSON");
+        assert!(parsed.get("event").is_some());
+    }
+
+    let paths: Vec<String> = lines
+        .iter()
+        .map(|l| {
+            let v: serde_json::Value = serde_json::from_str(l).unwrap();
+            v["path"].as_str().unwrap().to_string()
+        })
+        .collect();
+    assert!(paths.iter().any(|p| p == "app/secret1"));
+    assert!(paths.iter().any(|p| p == "app/secret2"));
+    assert!(paths.iter().any(|p| p == "app/secret3"));
+}
+
+#[test]
+fn test_audit_logger_creates_parent_directories() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir
+        .path()
+        .join("deeply")
+        .join("nested")
+        .join("audit.jsonl");
+    let logger = AuditLogger::new(&file_config(log_path.to_str().unwrap()));
+
+    logger.log(&AuditEvent::new("rotate", "app/db", "file"));
+
+    assert!(log_path.exists(), "log file should have been created");
+    let contents = std::fs::read_to_string(&log_path).unwrap();
+    let _: serde_json::Value = serde_json::from_str(contents.trim())
+        .expect("written line must be valid JSON");
+}
+
+#[test]
+fn test_audit_logger_no_op_when_disabled() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("audit.jsonl");
+
+    let logger = AuditLogger::new(&disabled_config());
+    logger.log(&AuditEvent::new("rotate", "app/db", "vault"));
+
+    assert!(
+        !log_path.exists(),
+        "disabled logger should not create a file"
+    );
+}
+
+#[test]
+fn test_audit_event_asr_version_is_present() {
+    let ev = AuditEvent::new("rotate", "app/db", "vault");
+    assert!(!ev.asr_version.is_empty(), "asr_version should be populated");
+}

--- a/tests/github_target_tests.rs
+++ b/tests/github_target_tests.rs
@@ -78,9 +78,10 @@ async fn test_github_secret_name_and_variable_name_are_mutually_exclusive() {
 
 #[tokio::test]
 async fn test_github_requires_token() {
-    if std::env::var("GITHUB_TOKEN").is_ok() {
-        return;
-    }
+    // Temporarily clear GITHUB_TOKEN so the test is deterministic regardless of environment.
+    let saved = std::env::var("GITHUB_TOKEN").ok();
+    std::env::remove_var("GITHUB_TOKEN");
+
     let config = GitHubTargetConfig {
         owner: "myorg".to_string(),
         repo: "myrepo".to_string(),
@@ -92,6 +93,11 @@ async fn test_github_requires_token() {
         api_url: None,
     };
     let result = GitHubTarget::new(&config).await;
+
+    if let Some(v) = saved {
+        std::env::set_var("GITHUB_TOKEN", v);
+    }
+
     assert!(result.is_err());
     let msg = result.err().unwrap().to_string();
     assert!(

--- a/tests/github_target_tests.rs
+++ b/tests/github_target_tests.rs
@@ -162,13 +162,15 @@ async fn test_github_update_variable_patches_existing() -> Result<()> {
         .await;
 
     let patch_mock = server
-        .mock("PATCH", "/repos/myorg/myrepo/actions/variables/EXISTING_VAR")
+        .mock(
+            "PATCH",
+            "/repos/myorg/myrepo/actions/variables/EXISTING_VAR",
+        )
         .with_status(204)
         .create_async()
         .await;
 
-    let target =
-        GitHubTarget::new(&variable_config(&server.url(), "EXISTING_VAR")).await?;
+    let target = GitHubTarget::new(&variable_config(&server.url(), "EXISTING_VAR")).await?;
     target.update_password("", "new-value").await?;
 
     get_mock.assert_async().await;
@@ -229,9 +231,9 @@ async fn test_github_update_secret_fetches_pubkey_and_uploads() -> Result<()> {
     // Use a real X25519 public key so the sealed-box encryption succeeds.
     // Curve25519 base point in little-endian (the "9" point).
     let pk_bytes: [u8; 32] = [
-        0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
+        0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00,
     ];
     let pk_b64 = base64::encode(&pk_bytes);
 
@@ -239,9 +241,7 @@ async fn test_github_update_secret_fetches_pubkey_and_uploads() -> Result<()> {
         .mock("GET", "/repos/myorg/myrepo/actions/secrets/public-key")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(format!(
-            r#"{{"key_id":"key_abc123","key":"{pk_b64}"}}"#
-        ))
+        .with_body(format!(r#"{{"key_id":"key_abc123","key":"{pk_b64}"}}"#))
         .create_async()
         .await;
 

--- a/tests/github_target_tests.rs
+++ b/tests/github_target_tests.rs
@@ -1,0 +1,300 @@
+#![cfg(feature = "github")]
+
+use anyhow::Result;
+use secret_rotator::config::GitHubTargetConfig;
+use secret_rotator::targets::{GitHubTarget, Target};
+
+fn variable_config(server_url: &str, var: &str) -> GitHubTargetConfig {
+    GitHubTargetConfig {
+        owner: "myorg".to_string(),
+        repo: "myrepo".to_string(),
+        secret_name: None,
+        variable_name: Some(var.to_string()),
+        token: Some("ghp_test_token".to_string()),
+        token_path: None,
+        env_name: None,
+        api_url: Some(server_url.to_string()),
+    }
+}
+
+fn secret_config(server_url: &str, secret: &str) -> GitHubTargetConfig {
+    GitHubTargetConfig {
+        owner: "myorg".to_string(),
+        repo: "myrepo".to_string(),
+        secret_name: Some(secret.to_string()),
+        variable_name: None,
+        token: Some("ghp_test_token".to_string()),
+        token_path: None,
+        env_name: None,
+        api_url: Some(server_url.to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Construction validation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_github_requires_secret_name_or_variable_name() {
+    let config = GitHubTargetConfig {
+        owner: "myorg".to_string(),
+        repo: "myrepo".to_string(),
+        secret_name: None,
+        variable_name: None,
+        token: Some("ghp_tok".to_string()),
+        token_path: None,
+        env_name: None,
+        api_url: None,
+    };
+    let result = GitHubTarget::new(&config).await;
+    assert!(result.is_err());
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains("secret_name or variable_name"),
+        "error should mention the two fields: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_github_secret_name_and_variable_name_are_mutually_exclusive() {
+    let config = GitHubTargetConfig {
+        owner: "myorg".to_string(),
+        repo: "myrepo".to_string(),
+        secret_name: Some("MY_SECRET".to_string()),
+        variable_name: Some("MY_VAR".to_string()),
+        token: Some("ghp_tok".to_string()),
+        token_path: None,
+        env_name: None,
+        api_url: None,
+    };
+    let result = GitHubTarget::new(&config).await;
+    assert!(result.is_err());
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains("mutually exclusive"),
+        "error should say mutually exclusive: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_github_requires_token() {
+    if std::env::var("GITHUB_TOKEN").is_ok() {
+        return;
+    }
+    let config = GitHubTargetConfig {
+        owner: "myorg".to_string(),
+        repo: "myrepo".to_string(),
+        secret_name: None,
+        variable_name: Some("MY_VAR".to_string()),
+        token: None,
+        token_path: None,
+        env_name: None,
+        api_url: None,
+    };
+    let result = GitHubTarget::new(&config).await;
+    assert!(result.is_err());
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.to_lowercase().contains("token"),
+        "error should mention missing token: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Trait properties
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_github_does_not_require_username() -> Result<()> {
+    let server = mockito::Server::new_async().await;
+    let target = GitHubTarget::new(&variable_config(&server.url(), "MY_VAR")).await?;
+    assert!(!target.requires_username());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_github_target_type_label() -> Result<()> {
+    let server = mockito::Server::new_async().await;
+    let target = GitHubTarget::new(&variable_config(&server.url(), "MY_VAR")).await?;
+    assert_eq!(target.target_type(), "GitHub");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// update_password — variables
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_github_update_variable_creates_when_not_found() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+
+    let get_mock = server
+        .mock("GET", "/repos/myorg/myrepo/actions/variables/NEW_VAR")
+        .with_status(404)
+        .with_body(r#"{"message":"Not Found"}"#)
+        .create_async()
+        .await;
+
+    let post_mock = server
+        .mock("POST", "/repos/myorg/myrepo/actions/variables")
+        .with_status(201)
+        .create_async()
+        .await;
+
+    let target = GitHubTarget::new(&variable_config(&server.url(), "NEW_VAR")).await?;
+    target.update_password("", "new-value").await?;
+
+    get_mock.assert_async().await;
+    post_mock.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_github_update_variable_patches_existing() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+
+    let get_mock = server
+        .mock("GET", "/repos/myorg/myrepo/actions/variables/EXISTING_VAR")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"name":"EXISTING_VAR","value":"old"}"#)
+        .create_async()
+        .await;
+
+    let patch_mock = server
+        .mock("PATCH", "/repos/myorg/myrepo/actions/variables/EXISTING_VAR")
+        .with_status(204)
+        .create_async()
+        .await;
+
+    let target =
+        GitHubTarget::new(&variable_config(&server.url(), "EXISTING_VAR")).await?;
+    target.update_password("", "new-value").await?;
+
+    get_mock.assert_async().await;
+    patch_mock.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_github_update_variable_env_scoped_create() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+
+    let get_mock = server
+        .mock(
+            "GET",
+            "/repos/myorg/myrepo/environments/production/variables/MY_VAR",
+        )
+        .with_status(404)
+        .create_async()
+        .await;
+
+    let post_mock = server
+        .mock(
+            "POST",
+            "/repos/myorg/myrepo/environments/production/variables",
+        )
+        .with_status(201)
+        .create_async()
+        .await;
+
+    let config = GitHubTargetConfig {
+        owner: "myorg".to_string(),
+        repo: "myrepo".to_string(),
+        secret_name: None,
+        variable_name: Some("MY_VAR".to_string()),
+        token: Some("ghp_tok".to_string()),
+        token_path: None,
+        env_name: Some("production".to_string()),
+        api_url: Some(server.url()),
+    };
+    let target = GitHubTarget::new(&config).await?;
+    target.update_password("", "val").await?;
+
+    get_mock.assert_async().await;
+    post_mock.assert_async().await;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// update_password — secrets (NaCl sealed-box path)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_github_update_secret_fetches_pubkey_and_uploads() -> Result<()> {
+    use secret_rotator::util::base64;
+
+    let mut server = mockito::Server::new_async().await;
+
+    // Use a real X25519 public key so the sealed-box encryption succeeds.
+    // Curve25519 base point in little-endian (the "9" point).
+    let pk_bytes: [u8; 32] = [
+        0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    ];
+    let pk_b64 = base64::encode(&pk_bytes);
+
+    let pk_mock = server
+        .mock("GET", "/repos/myorg/myrepo/actions/secrets/public-key")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"key_id":"key_abc123","key":"{pk_b64}"}}"#
+        ))
+        .create_async()
+        .await;
+
+    let put_mock = server
+        .mock("PUT", "/repos/myorg/myrepo/actions/secrets/MY_SECRET")
+        .with_status(204)
+        .create_async()
+        .await;
+
+    let target = GitHubTarget::new(&secret_config(&server.url(), "MY_SECRET")).await?;
+    target.update_password("", "new-secret-value").await?;
+
+    pk_mock.assert_async().await;
+    put_mock.assert_async().await;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// verify_connection
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_github_verify_connection_get_repo() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+
+    let get_mock = server
+        .mock("GET", "/repos/myorg/myrepo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":1,"name":"myrepo","full_name":"myorg/myrepo"}"#)
+        .create_async()
+        .await;
+
+    let target = GitHubTarget::new(&variable_config(&server.url(), "MY_VAR")).await?;
+    target.verify_connection("", "", None).await?;
+
+    get_mock.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_github_verify_connection_401_fails() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+
+    let _get = server
+        .mock("GET", "/repos/myorg/myrepo")
+        .with_status(401)
+        .with_body(r#"{"message":"Unauthorized"}"#)
+        .create_async()
+        .await;
+
+    let target = GitHubTarget::new(&variable_config(&server.url(), "MY_VAR")).await?;
+    let result = target.verify_connection("", "", None).await;
+    assert!(result.is_err(), "401 should produce an error");
+    Ok(())
+}

--- a/tests/gitlab_target_tests.rs
+++ b/tests/gitlab_target_tests.rs
@@ -1,0 +1,231 @@
+#![cfg(feature = "gitlab")]
+
+use anyhow::Result;
+use secret_rotator::config::GitLabTargetConfig;
+use secret_rotator::targets::{GitLabTarget, Target};
+
+fn gitlab_config(server_url: &str, project_id: &str, var_key: &str) -> GitLabTargetConfig {
+    GitLabTargetConfig {
+        project_id: project_id.to_string(),
+        variable_key: var_key.to_string(),
+        gitlab_url: Some(server_url.to_string()),
+        token: Some("glpat-test-token".to_string()),
+        token_path: None,
+        masked: None,
+        protected: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Target trait properties
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_gitlab_target_does_not_require_username() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/api/v4/projects/1")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":1,"name":"test"}"#)
+        .create_async()
+        .await;
+
+    let target = GitLabTarget::new(&gitlab_config(&server.url(), "1", "MY_VAR")).await?;
+    assert!(!target.requires_username());
+    assert_eq!(target.target_type(), "GitLab");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// update_password — update an existing variable (PUT → 200)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_gitlab_update_existing_variable_sends_put() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+    let put_mock = server
+        .mock("PUT", "/api/v4/projects/123/variables/DB_PASSWORD")
+        .match_header("PRIVATE-TOKEN", "glpat-test-token")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"key":"DB_PASSWORD","value":"newpass"}"#)
+        .create_async()
+        .await;
+
+    let config = GitLabTargetConfig {
+        project_id: "123".to_string(),
+        variable_key: "DB_PASSWORD".to_string(),
+        gitlab_url: Some(server.url()),
+        token: Some("glpat-test-token".to_string()),
+        token_path: None,
+        masked: Some(false),
+        protected: Some(false),
+    };
+    let target = GitLabTarget::new(&config).await?;
+    target.update_password("", "newpass").await?;
+
+    put_mock.assert_async().await;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// update_password — variable absent: PUT → 404 then POST → 201
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_gitlab_creates_variable_when_put_returns_404() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+
+    let put_mock = server
+        .mock("PUT", "/api/v4/projects/42/variables/NEW_VAR")
+        .with_status(404)
+        .with_body(r#"{"message":"Not Found"}"#)
+        .create_async()
+        .await;
+
+    let post_mock = server
+        .mock("POST", "/api/v4/projects/42/variables")
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"key":"NEW_VAR","value":"newpass"}"#)
+        .create_async()
+        .await;
+
+    let target = GitLabTarget::new(&gitlab_config(&server.url(), "42", "NEW_VAR")).await?;
+    target.update_password("", "newpass").await?;
+
+    put_mock.assert_async().await;
+    post_mock.assert_async().await;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// update_password — server error propagates
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_gitlab_update_propagates_server_error() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+
+    let _put = server
+        .mock("PUT", "/api/v4/projects/1/variables/MY_VAR")
+        .with_status(500)
+        .with_body(r#"{"message":"Internal Server Error"}"#)
+        .create_async()
+        .await;
+
+    let target = GitLabTarget::new(&gitlab_config(&server.url(), "1", "MY_VAR")).await?;
+    let result = target.update_password("", "pass").await;
+    assert!(result.is_err(), "server error should be propagated");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// update_password — slash in project ID is percent-encoded
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_gitlab_project_path_slash_is_encoded() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+
+    // "mygroup/myproject" should appear as "mygroup%2Fmyproject" in the URL
+    let put_mock = server
+        .mock("PUT", "/api/v4/projects/mygroup%2Fmyproject/variables/MY_VAR")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"key":"MY_VAR","value":"v"}"#)
+        .create_async()
+        .await;
+
+    let target =
+        GitLabTarget::new(&gitlab_config(&server.url(), "mygroup/myproject", "MY_VAR")).await?;
+    target.update_password("", "v").await?;
+
+    put_mock.assert_async().await;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// verify_connection — GET project succeeds
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_gitlab_verify_connection_get_project() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+
+    let get_mock = server
+        .mock("GET", "/api/v4/projects/99")
+        .match_header("PRIVATE-TOKEN", "glpat-test-token")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":99,"name":"test-project"}"#)
+        .create_async()
+        .await;
+
+    let target = GitLabTarget::new(&gitlab_config(&server.url(), "99", "MY_VAR")).await?;
+    target.verify_connection("", "", None).await?;
+
+    get_mock.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_gitlab_verify_connection_failure_propagates_error() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+
+    let _get = server
+        .mock("GET", "/api/v4/projects/1")
+        .with_status(401)
+        .with_body(r#"{"message":"401 Unauthorized"}"#)
+        .create_async()
+        .await;
+
+    let target = GitLabTarget::new(&gitlab_config(&server.url(), "1", "MY_VAR")).await?;
+    let result = target.verify_connection("", "", None).await;
+    assert!(result.is_err(), "401 should propagate as an error");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// masked / protected flags are passed in create body
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_gitlab_create_body_includes_masked_flag() -> Result<()> {
+    let mut server = mockito::Server::new_async().await;
+
+    // PUT → 404 forces creation
+    let _put = server
+        .mock("PUT", "/api/v4/projects/1/variables/SECRET_VAR")
+        .with_status(404)
+        .create_async()
+        .await;
+
+    let post_mock = server
+        .mock("POST", "/api/v4/projects/1/variables")
+        .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+            "key": "SECRET_VAR",
+            "masked": true,
+        })))
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"key":"SECRET_VAR","value":"s"}"#)
+        .create_async()
+        .await;
+
+    let config = GitLabTargetConfig {
+        project_id: "1".to_string(),
+        variable_key: "SECRET_VAR".to_string(),
+        gitlab_url: Some(server.url()),
+        token: Some("tok".to_string()),
+        token_path: None,
+        masked: Some(true),
+        protected: Some(false),
+    };
+    let target = GitLabTarget::new(&config).await?;
+    target.update_password("", "s").await?;
+
+    post_mock.assert_async().await;
+    Ok(())
+}

--- a/tests/gitlab_target_tests.rs
+++ b/tests/gitlab_target_tests.rs
@@ -131,7 +131,10 @@ async fn test_gitlab_project_path_slash_is_encoded() -> Result<()> {
 
     // "mygroup/myproject" should appear as "mygroup%2Fmyproject" in the URL
     let put_mock = server
-        .mock("PUT", "/api/v4/projects/mygroup%2Fmyproject/variables/MY_VAR")
+        .mock(
+            "PUT",
+            "/api/v4/projects/mygroup%2Fmyproject/variables/MY_VAR",
+        )
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"key":"MY_VAR","value":"v"}"#)

--- a/tests/notification_tests.rs
+++ b/tests/notification_tests.rs
@@ -31,10 +31,7 @@ fn test_should_notify_false_when_no_webhook() {
 
 #[test]
 fn test_should_notify_false_for_event_not_in_list() {
-    let client = NotificationClient::new(&cfg(
-        Some("http://example.com/hook"),
-        &["rotate"],
-    ));
+    let client = NotificationClient::new(&cfg(Some("http://example.com/hook"), &["rotate"]));
     assert!(!client.should_notify("flag"));
     assert!(!client.should_notify("scan"));
     assert!(!client.should_notify("unknown_event"));
@@ -67,18 +64,19 @@ fn test_is_enabled_reflects_webhook_presence() {
 async fn test_notify_rotate_no_op_when_no_webhook() {
     let client = NotificationClient::new(&cfg(None, &["rotate"]));
     // Should return Ok without making any network call
-    let result = client.notify_rotate("app/db", "vault", "success", None).await;
+    let result = client
+        .notify_rotate("app/db", "vault", "success", None)
+        .await;
     assert!(result.is_ok());
 }
 
 #[tokio::test]
 async fn test_notify_rotate_no_op_when_event_not_in_list() {
     // webhook is set but "rotate" not in events list
-    let client = NotificationClient::new(&cfg(
-        Some("http://127.0.0.1:1/unreachable"),
-        &["flag"],
-    ));
-    let result = client.notify_rotate("app/db", "vault", "success", None).await;
+    let client = NotificationClient::new(&cfg(Some("http://127.0.0.1:1/unreachable"), &["flag"]));
+    let result = client
+        .notify_rotate("app/db", "vault", "success", None)
+        .await;
     assert!(result.is_ok(), "should skip without error: {:?}", result);
 }
 
@@ -117,7 +115,9 @@ async fn test_notify_rotate_swallows_non_2xx_response() {
     let url = format!("{}/hook", server.url());
     let client = NotificationClient::new(&cfg(Some(&url), &["rotate"]));
     // 503 must not bubble up as an error
-    let result = client.notify_rotate("app/db", "vault", "success", None).await;
+    let result = client
+        .notify_rotate("app/db", "vault", "success", None)
+        .await;
     assert!(result.is_ok(), "non-2xx should be swallowed: {:?}", result);
 }
 

--- a/tests/notification_tests.rs
+++ b/tests/notification_tests.rs
@@ -1,0 +1,237 @@
+use secret_rotator::config::NotificationConfig;
+use secret_rotator::notification::NotificationClient;
+
+fn cfg(webhook: Option<&str>, events: &[&str]) -> NotificationConfig {
+    NotificationConfig {
+        webhook_url: webhook.map(|s| s.to_string()),
+        auth_header: None,
+        events: events.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+fn cfg_with_auth(webhook: &str, auth: &str, events: &[&str]) -> NotificationConfig {
+    NotificationConfig {
+        webhook_url: Some(webhook.to_string()),
+        auth_header: Some(auth.to_string()),
+        events: events.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// should_notify
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_should_notify_false_when_no_webhook() {
+    let client = NotificationClient::new(&cfg(None, &["rotate", "flag", "scan"]));
+    assert!(!client.should_notify("rotate"));
+    assert!(!client.should_notify("flag"));
+    assert!(!client.should_notify("scan"));
+}
+
+#[test]
+fn test_should_notify_false_for_event_not_in_list() {
+    let client = NotificationClient::new(&cfg(
+        Some("http://example.com/hook"),
+        &["rotate"],
+    ));
+    assert!(!client.should_notify("flag"));
+    assert!(!client.should_notify("scan"));
+    assert!(!client.should_notify("unknown_event"));
+}
+
+#[test]
+fn test_should_notify_true_for_configured_event() {
+    let client = NotificationClient::new(&cfg(
+        Some("http://example.com/hook"),
+        &["rotate", "flag", "scan"],
+    ));
+    assert!(client.should_notify("rotate"));
+    assert!(client.should_notify("flag"));
+    assert!(client.should_notify("scan"));
+}
+
+#[test]
+fn test_is_enabled_reflects_webhook_presence() {
+    let disabled = NotificationClient::new(&cfg(None, &["rotate"]));
+    let enabled = NotificationClient::new(&cfg(Some("http://example.com/hook"), &["rotate"]));
+    assert!(!disabled.is_enabled());
+    assert!(enabled.is_enabled());
+}
+
+// ---------------------------------------------------------------------------
+// notify_rotate — no-op paths
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_notify_rotate_no_op_when_no_webhook() {
+    let client = NotificationClient::new(&cfg(None, &["rotate"]));
+    // Should return Ok without making any network call
+    let result = client.notify_rotate("app/db", "vault", "success", None).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_notify_rotate_no_op_when_event_not_in_list() {
+    // webhook is set but "rotate" not in events list
+    let client = NotificationClient::new(&cfg(
+        Some("http://127.0.0.1:1/unreachable"),
+        &["flag"],
+    ));
+    let result = client.notify_rotate("app/db", "vault", "success", None).await;
+    assert!(result.is_ok(), "should skip without error: {:?}", result);
+}
+
+// ---------------------------------------------------------------------------
+// notify_rotate — HTTP interaction
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_notify_rotate_posts_to_webhook() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/hook")
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let url = format!("{}/hook", server.url());
+    let client = NotificationClient::new(&cfg(Some(&url), &["rotate"]));
+    client
+        .notify_rotate("app/db", "vault", "success", None)
+        .await
+        .unwrap();
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_notify_rotate_swallows_non_2xx_response() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("POST", "/hook")
+        .with_status(503)
+        .create_async()
+        .await;
+
+    let url = format!("{}/hook", server.url());
+    let client = NotificationClient::new(&cfg(Some(&url), &["rotate"]));
+    // 503 must not bubble up as an error
+    let result = client.notify_rotate("app/db", "vault", "success", None).await;
+    assert!(result.is_ok(), "non-2xx should be swallowed: {:?}", result);
+}
+
+#[tokio::test]
+async fn test_notify_rotate_includes_error_field() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/hook")
+        .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+            "event": "rotated",
+            "status": "failed",
+            "error": "connection refused",
+        })))
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let url = format!("{}/hook", server.url());
+    let client = NotificationClient::new(&cfg(Some(&url), &["rotate"]));
+    client
+        .notify_rotate("app/db", "vault", "failed", Some("connection refused"))
+        .await
+        .unwrap();
+
+    mock.assert_async().await;
+}
+
+// ---------------------------------------------------------------------------
+// notify_flag
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_notify_flag_no_op_when_disabled() {
+    let client = NotificationClient::new(&cfg(None, &["flag"]));
+    let result = client.notify_flag("app/cert", "vault", 12).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_notify_flag_posts_correct_event() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/hook")
+        .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+            "event": "flagged",
+            "path": "app/cert",
+            "rotation_period_months": 6,
+        })))
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let url = format!("{}/hook", server.url());
+    let client = NotificationClient::new(&cfg(Some(&url), &["flag"]));
+    client.notify_flag("app/cert", "vault", 6).await.unwrap();
+
+    mock.assert_async().await;
+}
+
+// ---------------------------------------------------------------------------
+// notify_scan
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_notify_scan_no_op_when_disabled() {
+    let client = NotificationClient::new(&cfg(None, &["scan"]));
+    let result = client.notify_scan("", "vault", 3).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_notify_scan_posts_correct_event() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/hook")
+        .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+            "event": "scanned",
+            "secrets_due": 5,
+        })))
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let url = format!("{}/hook", server.url());
+    let client = NotificationClient::new(&cfg(Some(&url), &["scan"]));
+    client.notify_scan("app", "vault", 5).await.unwrap();
+
+    mock.assert_async().await;
+}
+
+// ---------------------------------------------------------------------------
+// Auth header forwarding
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_notify_sends_auth_header_when_configured() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/hook")
+        .match_header("Authorization", "Bearer super-secret-token")
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let url = format!("{}/hook", server.url());
+    let client = NotificationClient::new(&cfg_with_auth(
+        &url,
+        "Bearer super-secret-token",
+        &["rotate"],
+    ));
+    client
+        .notify_rotate("path", "vault", "success", None)
+        .await
+        .unwrap();
+
+    mock.assert_async().await;
+}

--- a/tests/rotation_function_tests.rs
+++ b/tests/rotation_function_tests.rs
@@ -139,7 +139,10 @@ async fn test_rotate_secret_each_call_generates_different_value() -> Result<()> 
 
     let first = rotate_secret(&backend, "app/db", 32).await?;
     let second = rotate_secret(&backend, "app/db", 32).await?;
-    assert_ne!(first, second, "consecutive rotations should produce distinct secrets");
+    assert_ne!(
+        first, second,
+        "consecutive rotations should produce distinct secrets"
+    );
     Ok(())
 }
 
@@ -196,14 +199,8 @@ async fn test_rotate_with_target_calls_update_and_verify() -> Result<()> {
 
     let target = MockTarget::new();
 
-    let new = rotate_secret_with_target(
-        &backend,
-        "app/db",
-        32,
-        Some(&target),
-        Some("admin"),
-    )
-    .await?;
+    let new =
+        rotate_secret_with_target(&backend, "app/db", 32, Some(&target), Some("admin")).await?;
 
     assert_eq!(target.update_call_count(), 1);
     assert_eq!(target.last_updated_password(), Some(new.clone()));
@@ -238,8 +235,7 @@ async fn test_rotate_with_target_that_requires_username_fails_when_none_given() 
     let mut target = MockTarget::new();
     target.needs_username = true;
 
-    let result =
-        rotate_secret_with_target(&backend, "app/db", 32, Some(&target), None).await;
+    let result = rotate_secret_with_target(&backend, "app/db", 32, Some(&target), None).await;
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
     assert!(
@@ -257,12 +253,14 @@ async fn test_rotate_with_target_username_not_required_works_without_one() -> Re
 
     let target = MockTarget::new();
 
-    let new =
-        rotate_secret_with_target(&backend, "app/var", 32, Some(&target), None).await?;
+    let new = rotate_secret_with_target(&backend, "app/var", 32, Some(&target), None).await?;
 
     let calls = target.update_calls.lock().unwrap();
     assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].0, "", "username should be empty string for username-free targets");
+    assert_eq!(
+        calls[0].0, "",
+        "username should be empty string for username-free targets"
+    );
     assert_eq!(calls[0].1, new);
     Ok(())
 }

--- a/tests/rotation_function_tests.rs
+++ b/tests/rotation_function_tests.rs
@@ -1,0 +1,436 @@
+use anyhow::Result;
+use chrono::{Duration, Utc};
+use secret_rotator::backends::{FileBackend, SecretBackend};
+use secret_rotator::rotation::{flag_for_rotation, rotate_secret, scan_for_rotation};
+use secret_rotator::rotation::{rotate_secret_with_target, rotate_secret_with_targets};
+use secret_rotator::targets::Target;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Mock target
+// ---------------------------------------------------------------------------
+
+struct MockTarget {
+    update_calls: Arc<Mutex<Vec<(String, String)>>>,
+    verify_calls: Arc<Mutex<Vec<(String, String)>>>,
+    fail_on_update: bool,
+    needs_username: bool,
+}
+
+impl MockTarget {
+    fn new() -> Self {
+        Self {
+            update_calls: Arc::new(Mutex::new(Vec::new())),
+            verify_calls: Arc::new(Mutex::new(Vec::new())),
+            fail_on_update: false,
+            needs_username: false,
+        }
+    }
+
+    fn update_call_count(&self) -> usize {
+        self.update_calls.lock().unwrap().len()
+    }
+
+    fn last_updated_password(&self) -> Option<String> {
+        self.update_calls
+            .lock()
+            .unwrap()
+            .last()
+            .map(|(_, p)| p.clone())
+    }
+}
+
+#[async_trait::async_trait]
+impl Target for MockTarget {
+    async fn update_password(&self, username: &str, new_password: &str) -> Result<()> {
+        if self.fail_on_update {
+            anyhow::bail!("mock target update failure");
+        }
+        self.update_calls
+            .lock()
+            .unwrap()
+            .push((username.to_string(), new_password.to_string()));
+        Ok(())
+    }
+
+    async fn verify_connection(
+        &self,
+        username: &str,
+        password: &str,
+        _extra: Option<&str>,
+    ) -> Result<()> {
+        self.verify_calls
+            .lock()
+            .unwrap()
+            .push((username.to_string(), password.to_string()));
+        Ok(())
+    }
+
+    fn target_type(&self) -> &'static str {
+        "mock"
+    }
+
+    fn requires_username(&self) -> bool {
+        self.needs_username
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn write_secret(backend: &FileBackend, path: &str, key: &str, value: &str) {
+    let mut data = HashMap::new();
+    data.insert(key.to_string(), value.to_string());
+    backend.write_secret(path, data).await.unwrap();
+}
+
+async fn flag_secret_as_overdue(backend: &FileBackend, path: &str) {
+    let mut meta = HashMap::new();
+    meta.insert("rotation_enabled".to_string(), "true".to_string());
+    let old = (Utc::now() - Duration::days(200)).to_rfc3339();
+    meta.insert("last_rotated".to_string(), old);
+    backend.update_metadata(path, meta).await.unwrap();
+}
+
+async fn flag_secret_as_fresh(backend: &FileBackend, path: &str) {
+    let mut meta = HashMap::new();
+    meta.insert("rotation_enabled".to_string(), "true".to_string());
+    meta.insert("last_rotated".to_string(), Utc::now().to_rfc3339());
+    backend.update_metadata(path, meta).await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// rotate_secret
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_rotate_secret_returns_secret_of_correct_length() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/db", "password", "old").await;
+
+    let new = rotate_secret(&backend, "app/db", 24).await?;
+    assert_eq!(new.len(), 24);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rotate_secret_stores_new_value_in_backend() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/db", "password", "old").await;
+
+    let new = rotate_secret(&backend, "app/db", 32).await?;
+
+    let stored = backend.read_secret("app/db").await?;
+    assert_eq!(stored.data.get("password"), Some(&new));
+    assert_ne!(new, "old");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rotate_secret_each_call_generates_different_value() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/db", "password", "original").await;
+
+    let first = rotate_secret(&backend, "app/db", 32).await?;
+    let second = rotate_secret(&backend, "app/db", 32).await?;
+    assert_ne!(first, second, "consecutive rotations should produce distinct secrets");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rotate_secret_updates_rotation_metadata() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/token", "token", "old").await;
+
+    rotate_secret(&backend, "app/token", 32).await?;
+
+    let meta = backend.read_metadata("app/token").await?;
+    assert_eq!(
+        meta.get("rotation_enabled"),
+        Some(&"true".to_string()),
+        "rotation_enabled should be set to true"
+    );
+    assert!(
+        meta.contains_key("last_rotated"),
+        "last_rotated timestamp should be written"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rotate_secret_picks_up_existing_key_name() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+
+    let mut data = HashMap::new();
+    data.insert("api_key".to_string(), "oldapikey".to_string());
+    backend.write_secret("app/apikey", data).await?;
+
+    rotate_secret(&backend, "app/apikey", 32).await?;
+
+    let stored = backend.read_secret("app/apikey").await?;
+    assert!(
+        stored.data.contains_key("api_key"),
+        "key name 'api_key' should be preserved"
+    );
+    assert_ne!(stored.data["api_key"], "oldapikey");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// rotate_secret_with_target
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_rotate_with_target_calls_update_and_verify() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/db", "password", "old").await;
+
+    let target = MockTarget::new();
+
+    let new = rotate_secret_with_target(
+        &backend,
+        "app/db",
+        32,
+        Some(&target),
+        Some("admin"),
+    )
+    .await?;
+
+    assert_eq!(target.update_call_count(), 1);
+    assert_eq!(target.last_updated_password(), Some(new.clone()));
+
+    let verify_calls = target.verify_calls.lock().unwrap();
+    assert_eq!(verify_calls.len(), 1);
+    assert_eq!(verify_calls[0].0, "admin");
+    assert_eq!(verify_calls[0].1, new);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rotate_with_no_target_still_rotates_backend() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/db", "password", "old").await;
+
+    let new = rotate_secret_with_target(&backend, "app/db", 32, None, None).await?;
+    assert_eq!(new.len(), 32);
+
+    let stored = backend.read_secret("app/db").await?;
+    assert_eq!(stored.data.get("password"), Some(&new));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rotate_with_target_that_requires_username_fails_when_none_given() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/db", "password", "old").await;
+
+    let mut target = MockTarget::new();
+    target.needs_username = true;
+
+    let result =
+        rotate_secret_with_target(&backend, "app/db", 32, Some(&target), None).await;
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.to_lowercase().contains("username"),
+        "error should mention username: {msg}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rotate_with_target_username_not_required_works_without_one() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/var", "secret", "old").await;
+
+    let target = MockTarget::new();
+
+    let new =
+        rotate_secret_with_target(&backend, "app/var", 32, Some(&target), None).await?;
+
+    let calls = target.update_calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "", "username should be empty string for username-free targets");
+    assert_eq!(calls[0].1, new);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// rotate_secret_with_targets
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_rotate_with_multiple_targets_all_receive_same_secret() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/db", "password", "old").await;
+
+    let t1 = MockTarget::new();
+    let t2 = MockTarget::new();
+    let calls1 = Arc::clone(&t1.update_calls);
+    let calls2 = Arc::clone(&t2.update_calls);
+
+    let targets: Vec<Box<dyn Target>> = vec![Box::new(t1), Box::new(t2)];
+
+    let new = rotate_secret_with_targets(&backend, "app/db", 32, &targets, None).await?;
+
+    let c1 = calls1.lock().unwrap();
+    let c2 = calls2.lock().unwrap();
+
+    assert_eq!(c1.len(), 1, "first target should be called once");
+    assert_eq!(c2.len(), 1, "second target should be called once");
+    assert_eq!(c1[0].1, new, "first target should get the new secret");
+    assert_eq!(
+        c2[0].1, new,
+        "second target should receive the same new secret"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rotate_with_single_target_in_slice() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/db", "password", "old").await;
+
+    let target = MockTarget::new();
+    let calls = Arc::clone(&target.update_calls);
+    let targets: Vec<Box<dyn Target>> = vec![Box::new(target)];
+
+    rotate_secret_with_targets(&backend, "app/db", 32, &targets, None).await?;
+
+    assert_eq!(calls.lock().unwrap().len(), 1);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// flag_for_rotation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_flag_for_rotation_sets_enabled_and_period() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/cred", "secret", "val").await;
+
+    flag_for_rotation(&backend, "app/cred", 3).await?;
+
+    let meta = backend.read_metadata("app/cred").await?;
+    assert_eq!(meta.get("rotation_enabled"), Some(&"true".to_string()));
+    assert_eq!(meta.get("rotation_period_months"), Some(&"3".to_string()));
+    assert!(meta.contains_key("last_rotated"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_flag_for_rotation_different_periods() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+    write_secret(&backend, "app/cred", "secret", "val").await;
+
+    for period in [1u32, 6, 12, 24] {
+        flag_for_rotation(&backend, "app/cred", period).await?;
+        let meta = backend.read_metadata("app/cred").await?;
+        assert_eq!(
+            meta.get("rotation_period_months"),
+            Some(&period.to_string()),
+            "period {period} should be stored"
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// scan_for_rotation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_scan_finds_overdue_flagged_secret() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+
+    write_secret(&backend, "app/overdue", "password", "pass").await;
+    flag_secret_as_overdue(&backend, "app/overdue").await;
+
+    let due = scan_for_rotation(&backend, "", 6).await?;
+
+    assert_eq!(due.len(), 1);
+    assert!(
+        due[0].contains("overdue"),
+        "overdue secret should be in results: {due:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_scan_does_not_return_fresh_secret() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+
+    write_secret(&backend, "app/fresh", "password", "pass").await;
+    flag_secret_as_fresh(&backend, "app/fresh").await;
+
+    let due = scan_for_rotation(&backend, "", 6).await?;
+    assert!(due.is_empty(), "fresh secret should not be in results");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_scan_skips_unflagged_secrets() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+
+    write_secret(&backend, "app/unflagged", "password", "pass").await;
+
+    let due = scan_for_rotation(&backend, "", 6).await?;
+    assert!(
+        due.is_empty(),
+        "secret with no rotation metadata should not appear"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_scan_returns_only_overdue_from_mixed_list() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+
+    write_secret(&backend, "app/overdue", "password", "p1").await;
+    flag_secret_as_overdue(&backend, "app/overdue").await;
+
+    write_secret(&backend, "app/fresh", "password", "p2").await;
+    flag_secret_as_fresh(&backend, "app/fresh").await;
+
+    write_secret(&backend, "app/unflagged", "password", "p3").await;
+
+    let due = scan_for_rotation(&backend, "", 6).await?;
+
+    assert_eq!(due.len(), 1);
+    assert!(
+        due[0].contains("overdue"),
+        "only overdue secret should appear: {due:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_scan_empty_path_returns_empty_for_empty_backend() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+
+    let due = scan_for_rotation(&backend, "", 6).await?;
+    assert!(due.is_empty());
+    Ok(())
+}

--- a/tests/rotation_function_tests.rs
+++ b/tests/rotation_function_tests.rs
@@ -432,3 +432,29 @@ async fn test_scan_empty_path_returns_empty_for_empty_backend() -> Result<()> {
     assert!(due.is_empty());
     Ok(())
 }
+
+#[tokio::test]
+async fn test_scan_non_empty_prefix_no_double_prefix() -> Result<()> {
+    // Regression test for FileBackend::list_secrets stripping base_dir instead of dir_path.
+    // Before the fix, scan_for_rotation("app", ...) would return "app/app/overdue" because
+    // list_secrets returned paths relative to base_dir rather than the queried prefix.
+    let temp = TempDir::new()?;
+    let backend = FileBackend::new(temp.path())?;
+
+    write_secret(&backend, "app/overdue", "password", "pass").await;
+    flag_secret_as_overdue(&backend, "app/overdue").await;
+
+    let due = scan_for_rotation(&backend, "app", 6).await?;
+
+    assert_eq!(
+        due.len(),
+        1,
+        "should find exactly one overdue secret: {due:?}"
+    );
+    assert_eq!(
+        due[0], "app/overdue",
+        "path should not be double-prefixed: got {:?}",
+        due[0]
+    );
+    Ok(())
+}

--- a/tests/vault_auth_tests.rs
+++ b/tests/vault_auth_tests.rs
@@ -1,0 +1,351 @@
+use secret_rotator::backends::VaultBackend;
+use secret_rotator::config::{
+    VaultAppRoleConfig, VaultConfig, VaultJwtConfig, VaultKubernetesConfig,
+};
+use tempfile::TempDir;
+
+fn vault_token_config(address: &str, token: Option<&str>) -> VaultConfig {
+    VaultConfig {
+        address: address.to_string(),
+        token: token.map(|t| t.to_string()),
+        mount: "secret".to_string(),
+        auth_method: "token".to_string(),
+        approle: None,
+        kubernetes: None,
+        aws_iam: None,
+        jwt: None,
+    }
+}
+
+fn vault_auth_response_body() -> &'static str {
+    r#"{"auth":{"client_token":"s.mock-token","renewable":true,"lease_duration":3600,"policies":["default"]}}"#
+}
+
+// ---------------------------------------------------------------------------
+// Token auth
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_token_auth_from_config_field() {
+    let config = vault_token_config("http://127.0.0.1:1", Some("s.direct-token"));
+    let result = VaultBackend::from_config(&config).await;
+    assert!(
+        result.is_ok(),
+        "token auth with config.token should succeed: {}",
+        result.err().map(|e| e.to_string()).unwrap_or_default()
+    );
+}
+
+#[tokio::test]
+async fn test_token_auth_missing_fails() {
+    // Ensure VAULT_TOKEN is not set for this test. If it is, the test is a no-op.
+    if std::env::var("VAULT_TOKEN").is_ok() {
+        return;
+    }
+    let config = vault_token_config("http://127.0.0.1:1", None);
+    let result = VaultBackend::from_config(&config).await;
+    assert!(result.is_err());
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.to_lowercase().contains("token"),
+        "error should mention token: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AppRole auth
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_approle_auth_success() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/auth/approle/login")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(vault_auth_response_body())
+        .create_async()
+        .await;
+
+    let config = VaultConfig {
+        address: server.url(),
+        token: None,
+        mount: "secret".to_string(),
+        auth_method: "approle".to_string(),
+        approle: Some(VaultAppRoleConfig {
+            role_id: "test-role-id".to_string(),
+            secret_id: Some("test-secret-id".to_string()),
+            secret_id_env: None,
+            mount: "approle".to_string(),
+        }),
+        kubernetes: None,
+        aws_iam: None,
+        jwt: None,
+    };
+
+    let result = VaultBackend::from_config(&config).await;
+    mock.assert_async().await;
+    assert!(
+        result.is_ok(),
+        "AppRole auth should succeed: {}",
+        result.err().map(|e| e.to_string()).unwrap_or_default()
+    );
+}
+
+#[tokio::test]
+async fn test_approle_auth_custom_mount() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/auth/my-approle/login")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(vault_auth_response_body())
+        .create_async()
+        .await;
+
+    let config = VaultConfig {
+        address: server.url(),
+        token: None,
+        mount: "secret".to_string(),
+        auth_method: "approle".to_string(),
+        approle: Some(VaultAppRoleConfig {
+            role_id: "role".to_string(),
+            secret_id: Some("secret".to_string()),
+            secret_id_env: None,
+            mount: "my-approle".to_string(),
+        }),
+        kubernetes: None,
+        aws_iam: None,
+        jwt: None,
+    };
+
+    let result = VaultBackend::from_config(&config).await;
+    mock.assert_async().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_approle_auth_server_403_fails() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/auth/approle/login")
+        .with_status(403)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"errors":["permission denied"]}"#)
+        .create_async()
+        .await;
+
+    let config = VaultConfig {
+        address: server.url(),
+        token: None,
+        mount: "secret".to_string(),
+        auth_method: "approle".to_string(),
+        approle: Some(VaultAppRoleConfig {
+            role_id: "bad-role".to_string(),
+            secret_id: Some("bad-secret".to_string()),
+            secret_id_env: None,
+            mount: "approle".to_string(),
+        }),
+        kubernetes: None,
+        aws_iam: None,
+        jwt: None,
+    };
+
+    let result = VaultBackend::from_config(&config).await;
+    mock.assert_async().await;
+    assert!(result.is_err(), "403 from Vault should produce an error");
+}
+
+#[tokio::test]
+async fn test_approle_auth_missing_config_section_fails() {
+    let config = VaultConfig {
+        address: "http://127.0.0.1:1".to_string(),
+        token: None,
+        mount: "secret".to_string(),
+        auth_method: "approle".to_string(),
+        approle: None,
+        kubernetes: None,
+        aws_iam: None,
+        jwt: None,
+    };
+
+    let result = VaultBackend::from_config(&config).await;
+    assert!(result.is_err());
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains("approle"),
+        "error should mention the missing section: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Kubernetes auth
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_kubernetes_auth_success() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/auth/kubernetes/login")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(vault_auth_response_body())
+        .create_async()
+        .await;
+
+    let temp = TempDir::new().unwrap();
+    let jwt_path = temp.path().join("sa-token");
+    std::fs::write(&jwt_path, "eyJhbGciOiJSUzI1NiJ9.fake-jwt-payload.fake-sig").unwrap();
+
+    let config = VaultConfig {
+        address: server.url(),
+        token: None,
+        mount: "secret".to_string(),
+        auth_method: "kubernetes".to_string(),
+        approle: None,
+        kubernetes: Some(VaultKubernetesConfig {
+            role: "asr-role".to_string(),
+            sa_token_path: jwt_path.to_str().unwrap().to_string(),
+            mount: "kubernetes".to_string(),
+        }),
+        aws_iam: None,
+        jwt: None,
+    };
+
+    let result = VaultBackend::from_config(&config).await;
+    mock.assert_async().await;
+    assert!(
+        result.is_ok(),
+        "Kubernetes auth should succeed: {}",
+        result.err().map(|e| e.to_string()).unwrap_or_default()
+    );
+}
+
+#[tokio::test]
+async fn test_kubernetes_auth_missing_jwt_file_fails() {
+    let config = VaultConfig {
+        address: "http://127.0.0.1:1".to_string(),
+        token: None,
+        mount: "secret".to_string(),
+        auth_method: "kubernetes".to_string(),
+        approle: None,
+        kubernetes: Some(VaultKubernetesConfig {
+            role: "asr-role".to_string(),
+            sa_token_path: "/nonexistent/path/to/token".to_string(),
+            mount: "kubernetes".to_string(),
+        }),
+        aws_iam: None,
+        jwt: None,
+    };
+
+    let result = VaultBackend::from_config(&config).await;
+    assert!(result.is_err());
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains("nonexistent") || msg.to_lowercase().contains("token"),
+        "error should describe the missing file: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// JWT auth
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_jwt_auth_from_explicit_env_var() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/auth/jwt/login")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(vault_auth_response_body())
+        .create_async()
+        .await;
+
+    // Use a distinctive env var name unlikely to be set in normal environments
+    let env_key = "ASR_TEST_VAULT_JWT_TOKEN_AUTH_TEST";
+    std::env::set_var(env_key, "eyJhbGciOiJSUzI1NiJ9.test-jwt.sig");
+
+    let config = VaultConfig {
+        address: server.url(),
+        token: None,
+        mount: "secret".to_string(),
+        auth_method: "jwt".to_string(),
+        approle: None,
+        kubernetes: None,
+        aws_iam: None,
+        jwt: Some(VaultJwtConfig {
+            role: "my-role".to_string(),
+            token_env: Some(env_key.to_string()),
+            mount: "jwt".to_string(),
+        }),
+    };
+
+    let result = VaultBackend::from_config(&config).await;
+    std::env::remove_var(env_key);
+    mock.assert_async().await;
+    assert!(
+        result.is_ok(),
+        "JWT auth from env var should succeed: {}",
+        result.err().map(|e| e.to_string()).unwrap_or_default()
+    );
+}
+
+#[tokio::test]
+async fn test_jwt_auth_missing_token_fails() {
+    let env_key = "ASR_TEST_VAULT_JWT_MISSING_TOKEN";
+    std::env::remove_var(env_key);
+
+    let config = VaultConfig {
+        address: "http://127.0.0.1:1".to_string(),
+        token: None,
+        mount: "secret".to_string(),
+        auth_method: "jwt".to_string(),
+        approle: None,
+        kubernetes: None,
+        aws_iam: None,
+        jwt: Some(VaultJwtConfig {
+            role: "my-role".to_string(),
+            token_env: Some(env_key.to_string()),
+            mount: "jwt".to_string(),
+        }),
+    };
+
+    let result = VaultBackend::from_config(&config).await;
+    assert!(result.is_err());
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains(env_key) || msg.to_lowercase().contains("token"),
+        "error should mention the missing token env var: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unknown auth method
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_unknown_auth_method_fails_with_helpful_message() {
+    let config = VaultConfig {
+        address: "http://127.0.0.1:1".to_string(),
+        token: None,
+        mount: "secret".to_string(),
+        auth_method: "foobar_auth".to_string(),
+        approle: None,
+        kubernetes: None,
+        aws_iam: None,
+        jwt: None,
+    };
+
+    let result = VaultBackend::from_config(&config).await;
+    assert!(result.is_err());
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains("foobar_auth"),
+        "error should name the unknown method: {msg}"
+    );
+    assert!(
+        msg.contains("approle") || msg.contains("Supported"),
+        "error should list supported methods: {msg}"
+    );
+}

--- a/tests/vault_auth_tests.rs
+++ b/tests/vault_auth_tests.rs
@@ -38,12 +38,17 @@ async fn test_token_auth_from_config_field() {
 
 #[tokio::test]
 async fn test_token_auth_missing_fails() {
-    // Ensure VAULT_TOKEN is not set for this test. If it is, the test is a no-op.
-    if std::env::var("VAULT_TOKEN").is_ok() {
-        return;
-    }
+    // Temporarily clear VAULT_TOKEN so the test is deterministic regardless of environment.
+    let saved = std::env::var("VAULT_TOKEN").ok();
+    std::env::remove_var("VAULT_TOKEN");
+
     let config = vault_token_config("http://127.0.0.1:1", None);
     let result = VaultBackend::from_config(&config).await;
+
+    if let Some(v) = saved {
+        std::env::set_var("VAULT_TOKEN", v);
+    }
+
     assert!(result.is_err());
     let msg = result.err().unwrap().to_string();
     assert!(


### PR DESCRIPTION
## Summary

- **78 new integration/unit tests** across 6 new test files
- **FileBackend bug fix**: `list_secrets` was stripping `self.base_dir` instead of `dir_path`, causing double-path-prefixing in `scan_for_rotation` calls with a non-empty path argument
- **GitHub testability**: added `api_url: Option<String>` to `GitHubTargetConfig` and `api_base: String` to `GitHubTarget` so HTTP-level tests can inject a mock server URL

## New test files

| File | Tests | What it covers |
|---|---|---|
| `tests/audit_tests.rs` | 16 | `AuditEvent` builder chain, JSONL serialization, file append mode, parent dir creation, disabled no-op |
| `tests/notification_tests.rs` | 14 | `should_notify` logic, no-op paths, HTTP POST bodies, non-2xx swallowing, `Authorization` header forwarding |
| `tests/github_target_tests.rs` | 11 | Construction validation, variable create (GET 404→POST) and patch (GET 200→PATCH), env-scoped variables, NaCl secret upload (fetches pubkey, PUT), `verify_connection` success/401 |
| `tests/gitlab_target_tests.rs` | 8 | PUT→200 update, PUT→404→POST create, 500 propagation, slash-encoded project path, `verify_connection`, `masked` body flag |
| `tests/vault_auth_tests.rs` | 11 | All four auth methods (token, AppRole, Kubernetes, JWT) via mockito; custom mounts; missing-config errors |
| `tests/rotation_function_tests.rs` | 18 | `rotate_secret`, `rotate_secret_with_target`, `rotate_secret_with_targets`, `flag_for_rotation`, `scan_for_rotation` via inline `MockTarget` over `Arc<Mutex<Vec<...>>>` |

## Bug fix: `FileBackend::list_secrets`

Previously `strip_prefix(&self.base_dir)` was used, so callers always received full paths relative to the base dir. `scan_for_rotation` (and Vault's LIST equivalent) expects paths relative to the *queried* prefix. This caused `scan_for_rotation(app)` to return `app/app/secret` instead of `app/secret`. Fixed by stripping `dir_path` and adjusting recursive subdirectory prefixing accordingly.

## Test plan

- [ ] `cargo test --all-features` — all 78+ tests pass, zero failures
- [ ] No warnings (removed two `unused_mut` in GitHub tests)
- [ ] FileBackend fix verified by `test_scan_finds_overdue_flagged_secret` passing with a non-empty path

🤖 Generated with [Claude Code](https://claude.com/claude-code)